### PR TITLE
Not able to get the mocks working with DI in TESTS. Fake Implementati…

### DIFF
--- a/src/Habitude.DropImageEventHandler.Tests/Habitude.DropImageEventHandler.Tests.csproj
+++ b/src/Habitude.DropImageEventHandler.Tests/Habitude.DropImageEventHandler.Tests.csproj
@@ -7,8 +7,10 @@
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.1.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="1.1.0" />
     <PackageReference Include="AWSSDK.S3" Version="3.3.110.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Microsoft.UnitTestFramework.Extensions" Version="2.0.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
   </ItemGroup>

--- a/src/Habitude.DropImageEventHandler.Tests/MockContainerBuilder.cs
+++ b/src/Habitude.DropImageEventHandler.Tests/MockContainerBuilder.cs
@@ -6,6 +6,8 @@ using Amazon.S3;
 using Habitude.Framework;
 using Habitude.Infrastructure.AWS.S3;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Moq;
 
 namespace Habitude.DropImageEventHandler.Tests
 {
@@ -15,6 +17,10 @@ namespace Habitude.DropImageEventHandler.Tests
     {
       var container = new ServiceCollection();
 
+      //Moq
+      var MockRepo = new Mock<IPhotoGalleryRepository>();
+      var MockProcessor = new Mock<IDropImageEventProcessor>();
+
       //Amazon.S3
       container.AddSingleton<IAmazonS3, AmazonS3Client>();
 
@@ -22,28 +28,12 @@ namespace Habitude.DropImageEventHandler.Tests
       container.AddSingleton<IS3Client, S3Client>();
 
       //Habitude.Framework
-      container.AddSingleton<IPhotoGalleryRepository, MockRepo>();
+      container.AddSingleton<IPhotoGalleryRepository, MockRepo.Object>();
 
       //Habitude.DropImageEventHandler
-      container.AddSingleton<IDropImageEventProcessor, MockProcessor>();
+      container.AddSingleton<IDropImageEventProcessor, MockProcessor.Object>();
 
       return container.BuildServiceProvider();
     }
   }
-
-  public class MockRepo : IPhotoGalleryRepository
-  {
-    public void GetItem()
-    {
-      throw new NotImplementedException();
-    }
-  }
-  public class MockProcessor : IDropImageEventProcessor
-  {
-    public void Process()
-    {
-      throw new NotImplementedException();
-    }
-  }
-
 }


### PR DESCRIPTION
Microsoft .Net Core's default dependency injection container does not allow registering instances (Mocked or not Mocked). 
Hence we need to implement the stubbed version of each and every object that needs to be mocked for testing.

Parking this for now.